### PR TITLE
Option to remove header and footer

### DIFF
--- a/aops-enhanced.user.js
+++ b/aops-enhanced.user.js
@@ -15,6 +15,7 @@ class EnhancedSettingsManager {
     notifications: true,
     post_links: true,
     feed_moderation: true,
+    kill_top: false,
     quote_primary: 'enhanced',
     quote_secondary: 'enhanced',
     time_format: '',
@@ -57,6 +58,7 @@ Some changes will not apply until the page is refreshed.<br>
 <label><input name='notifications' type='checkbox'> Notifications</label><br>
 <label><input name='post_links' type='checkbox'> Easy post links</label><br>
 <label><input name='feed_moderation' type='checkbox'> Enable moderator buttons in feed</label><br>
+<label><input name='kill_top' type='checkbox'> Simplify UI</label><br>
 <label>Quote mode <select name='quote_primary'>
 <option value='aops'>AoPS Default</option>
 <option value='enhanced'>Enhanced</option>
@@ -94,6 +96,51 @@ Some changes will not apply until the page is refreshed.<br>
 // Add CSS for feed moderation if enabled
 if (enhanced_settings.get('feed_moderation')) {
   document.head.appendChild(document.createElement('style')).textContent = '#feed-topic .cmty-topic-moderate{ display: inline !important; }';
+}
+if (enhanced_settings.get('kill_top')) {
+  const loginwrap = document.getElementsByClassName('menu-login-wrapper')[0];
+  loginwrap.id = 'loginwrap';
+  document.getElementById('header-wrapper').before(loginwrap);
+  document.head.appendChild(document.createElement('style')).textContent = `
+  #header-wrapper #header {
+    margin-top: 0px;
+    display: none !important;
+  }
+  #header-wrapper #header.visible-faded {
+    display: block !important;
+    position: absolute;
+    z-index: 5000;
+    opacity: 0.7;
+  }
+  #header-wrapper #header.visible-bright {
+    display: block !important;
+    position: absolute;
+    z-index: 5000;
+  }
+  #loginwrap {
+    position: absolute;
+    z-index: 10000;
+    top: 0;
+    right: 0;
+    background: #dedede;
+  }
+  #small-footer-wrapper {
+    display: none !important;
+  }
+  `;
+  const header = document.getElementById('header');
+  loginwrap.onmouseenter = () => {
+    header.classList.add('visible-faded');
+  };
+  loginwrap.onmouseleave = () => {
+    window.setTimeout(() => { header.classList.remove('visible-faded'); }, 150);
+  };
+  header.onmouseenter = () => {
+    header.classList.add('visible-bright');
+  };
+  header.onmouseleave = () => {
+    window.setTimeout(() => { header.classList.remove('visible-bright'); }, 150);
+  };
 }
 
 // Prevent errors when trying to modify AoPS Community on pages where it doesn't exist

--- a/aops-enhanced.user.js
+++ b/aops-enhanced.user.js
@@ -21,7 +21,7 @@ class EnhancedSettingsManager {
   };
 
   /**
-   * 
+   *
    * @param {string} storage_variable
    */
   constructor(storage_variable) {

--- a/aops-enhanced.user.js
+++ b/aops-enhanced.user.js
@@ -105,6 +105,7 @@ if (enhanced_settings.get('kill_top')) {
   #header-wrapper #header {
     margin-top: 0px;
     display: none !important;
+    transition: none !important;
   }
   #header-wrapper #header.visible-faded {
     display: block !important;
@@ -122,7 +123,9 @@ if (enhanced_settings.get('kill_top')) {
     z-index: 10000;
     top: 0;
     right: 0;
-    background: #dedede;
+  }
+  .mediawiki .menu-login-item, .online .menu-login-item {
+    color: #dedede;
   }
   #small-footer-wrapper {
     display: none !important;


### PR DESCRIPTION
saves a ton of vertical space

login menu moved to top of page; hovering over lets you get the links back if you do need them

![image](https://user-images.githubusercontent.com/3750940/125151915-77228c80-e0fe-11eb-94bd-1be10fd24e4e.png)
