### PR TITLE
Fixed border for username drop-down

### DIFF
--- a/aops-enhanced.user.js
+++ b/aops-enhanced.user.js
@@ -138,6 +138,13 @@ enhanced_settings.add_hook('kill_top', (() => {
 #small-footer-wrapper {
   display: none !important;
 }
+.login-dropdown-divider {
+  display:none !important;
+}
+.login-dropdown-content {
+  padding: 12px 12px 12px !important;
+  margin-top: 2px;
+}
 `;
   return value => {
     if (value) {

--- a/aops-enhanced.user.js
+++ b/aops-enhanced.user.js
@@ -143,7 +143,7 @@ enhanced_settings.add_hook('kill_top', (() => {
 }
 .login-dropdown-content {
   padding: 12px 12px 12px !important;
-  margin-top: 2px;
+  border-top: 2.4px #009fad solid;
 }
 `;
   return value => {


### PR DESCRIPTION
There was a border below the username dropdown when the "Simplify UI" option is checked. 

https://i.imgur.com/NY5GG4d.png

This can be fixed by adding

```css
.login-dropdown-divider {
  display:none !important;
}
.login-dropdown-content {
  padding: 12px 12px 12px !important;
  margin-top: 2px;
}
```

